### PR TITLE
base64 encode xml for saving

### DIFF
--- a/upload/admin/controller/extension/modification/editor.php
+++ b/upload/admin/controller/extension/modification/editor.php
@@ -133,7 +133,7 @@ EOT;
         if (!$this->user->hasPermission('modify', 'extension/modification/editor')) {
             $json['error'] = $this->language->get('error_permission');
         } else {
-            $xml = html_entity_decode($this->request->post['xml']);
+            $xml = base64_decode($this->request->post['xml']);
 
             if ($xml) {
                 if ($this->validate_xml($xml)) {

--- a/upload/admin/view/template/extension/modification/editor.twig
+++ b/upload/admin/view/template/extension/modification/editor.twig
@@ -127,7 +127,7 @@
       url: 'index.php?route=extension/modification/editor/save&user_token={{ user_token }}',
       type: 'post',
       dataType: 'json',
-      data: { modification_id: id, xml: xml_code },
+      data: { modification_id: id, xml: btoa(xml_code) },
       cache: false,
       beforeSend: function() {
         $('#button-save').button('loading');


### PR DESCRIPTION
Because ocmod xml often contains php code, some firewalls reject it. For example, Dreamhost rejects it with HTTP code 418. Suggesting a simple solution - base64 encode it before saving and decode it in the controller.